### PR TITLE
feat: Automatic Release detection (#335)

### DIFF
--- a/client.go
+++ b/client.go
@@ -208,7 +208,7 @@ func NewClient(options ClientOptions) (*Client, error) {
 	}
 
 	if options.Release == "" {
-		options.Release = os.Getenv("SENTRY_RELEASE")
+		options.Release = defaultRelease()
 	}
 
 	if options.Environment == "" {

--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	pkgErrors "github.com/pkg/errors"
 )
 
@@ -281,7 +282,8 @@ func TestCaptureEvent(t *testing.T) {
 		},
 	}
 	got := transport.lastEvent
-	if diff := cmp.Diff(want, got); diff != "" {
+	opts := cmp.Options{cmpopts.IgnoreFields(Event{}, "Release")}
+	if diff := cmp.Diff(want, got, opts); diff != "" {
 		t.Errorf("Event mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/fasthttp/sentryfasthttp_test.go
+++ b/fasthttp/sentryfasthttp_test.go
@@ -206,7 +206,7 @@ func TestIntegration(t *testing.T) {
 		cmpopts.IgnoreFields(
 			sentry.Event{},
 			"Contexts", "EventID", "Extra", "Platform",
-			"Sdk", "ServerName", "Tags", "Timestamp",
+			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
 		cmpopts.IgnoreMapEntries(func(k string, v string) bool {
 			// fasthttp changed Content-Length behavior in

--- a/http/sentryhttp_test.go
+++ b/http/sentryhttp_test.go
@@ -214,7 +214,7 @@ func TestIntegration(t *testing.T) {
 		cmpopts.IgnoreFields(
 			sentry.Event{},
 			"Contexts", "EventID", "Extra", "Platform",
-			"Sdk", "ServerName", "Tags", "Timestamp",
+			"Release", "Sdk", "ServerName", "Tags", "Timestamp",
 		),
 		cmpopts.IgnoreFields(
 			sentry.Request{},

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -151,7 +151,7 @@ func TestStartSpan(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(Event{},
 			"Contexts", "EventID", "Level", "Platform",
-			"Sdk", "ServerName",
+			"Release", "Sdk", "ServerName",
 		),
 		cmpopts.EquateEmpty(),
 	}
@@ -210,7 +210,7 @@ func TestStartChild(t *testing.T) {
 	opts := cmp.Options{
 		cmpopts.IgnoreFields(Event{},
 			"EventID", "Level", "Platform",
-			"Sdk", "ServerName", "Timestamp", "StartTime",
+			"Release", "Sdk", "ServerName", "Timestamp", "StartTime",
 		),
 		cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
 			return k != "trace"


### PR DESCRIPTION
Attempts to guess the release info, either by getting the last git
commit hash or by looking up some known environment variables that tracks
release identification.

<!--

Hey, thanks for your contribution!

The Sentry team has finite resources and priorities that are not always visible on GitHub.
Please help us save time when reviewing your PR by following this two-step guide:

1. Is your PR a simple typo fix? __Click that green "Create pull request" button__!
2. For more complex PRs, please read https://github.com/getsentry/sentry-go/blob/master/CONTRIBUTING.md

-->
